### PR TITLE
ユーザー別のHome/Mention抽出判定が常に失敗する問題の修正

### DIFF
--- a/twitter_datasource.rb
+++ b/twitter_datasource.rb
@@ -17,7 +17,7 @@ Plugin.create :twitter_datasource do
   end
 
   def active_datasources
-    Plugin.filtering(:active_datasources, Set.new)
+    Plugin.filtering(:active_datasources, Set.new).first
   end
 
   filter_extract_datasources do |ds|


### PR DESCRIPTION
https://dev.mikutter.hachune.net/issues/1410 に関連する修正です。

extract_datasources フィルタを呼び出した後、戻り値の先頭要素を取る処理が入っていないため、常にユーザー別の抽出判定が失敗していました。